### PR TITLE
[CE-2949]:Take Jenkins URL from the Global variables

### DIFF
--- a/resources/createJobs.sh
+++ b/resources/createJobs.sh
@@ -2,7 +2,6 @@
 
 set -x
 ADMIN_TOKEN=$1
-JENKINS_URL=$2
 
 if [[ -z "${ADMIN_TOKEN}" ]]; then
     echo "[ERROR]: Please pass an admin API Token as parameter"


### PR DESCRIPTION
- Removing unnecessary $JenkinsURL. It will be taken from the global variables